### PR TITLE
Jinja exclusive registry and engine

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,10 @@ matrix:
   include:
     - language: python
       python: 2.7
+      dist: trusty
       env:
         - TRAVIS_NODE_VERSION=8
-        - BROWSER=PhantomJS
+        - BROWSER=Firefox
     - language: python
       dist: trusty
       python: 3.4
@@ -32,7 +33,7 @@ matrix:
       python: 3.7
       dist: xenial
       env:
-        - TRAVIS_NODE_VERSION=12
+        - TRAVIS_NODE_VERSION=10
         - BROWSER=PhantomJS
     - language: python
       python: 3.8
@@ -47,15 +48,15 @@ matrix:
       dist: xenial
       env:
         - TRAVIS_NODE_VERSION=14
-        - BROWSER=PhantomJS
+        - BROWSER=Chrome
       addons:
         chrome: stable
     - language: python
-      dist: trusty
+      dist: xenial
       python: pypy
       env:
         - TRAVIS_NODE_VERSION=8
-        - BROWSER=Firefox
+        - BROWSER=PhantomJS
     - language: python
       python: pypy3
       env:

--- a/README.rst
+++ b/README.rst
@@ -75,6 +75,25 @@ Guidelines will be added as the system is formalized, and they follow:
   require.js, and so the option to build packages as AMD modules is
   permitted, though the standard CommonJS structure should work.
 
+Shared templates
+~~~~~~~~~~~~~~~~
+
+These are exposed through the ``nunja.molds`` registry as a complete
+set that includes client side scripts.
+
+Server-side only templates
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+These are exposed through the ``nunja.tmpl`` registry, and is intended
+for templates that generate the skeletal markup from which the molds may
+be nested.
+
+A more formal set of keywords may be developed in the future to better
+facilitate the above process.
+
+Currently, declaring templates under this registry will be useful for
+providing static templates across Python package boundaries.
+
 
 Deployment
 ----------

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,10 +18,10 @@ environment:
       nodejs_version: "10"
       BROWSER: "Firefox"
     - PYTHON: "C:\\Python37"
-      nodejs_version: "10"
+      nodejs_version: "12"
       BROWSER: "IE"
     - PYTHON: "C:\\Python38"
-      nodejs_version: "10"
+      nodejs_version: "12"
       BROWSER: "PhantomJS"
 matrix:
   allow_failures:

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,8 @@ setup(
     },
     entry_points={
         'calmjs.registry': [
+            # The template only registry.
+            'nunja.tmpl = nunja.registry:JinjaTemplateRegistry',
             # The main mold registry.
             'nunja.mold = nunja.registry:MoldRegistry',
             # The registry for the tests written originally that are
@@ -100,6 +102,9 @@ setup(
         'nunja.mold': [
             '_core_ = nunja:_core_',
             'nunja.molds = nunja:molds',
+        ],
+        'nunja.tmpl': [
+            'nunja.tmpl = nunja:molds',
         ],
         'nunja.mold.testing': [
             'nunja.testing.mold = nunja.testing:mold',

--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,7 @@ setup(
             'nunja.molds = nunja:molds',
         ],
         'nunja.tmpl': [
-            'nunja.tmpl = nunja:molds',
+            'nunja.tmpl = nunja:templates',
         ],
         'nunja.mold.testing': [
             'nunja.testing.mold = nunja.testing:mold',

--- a/src/nunja/templates/builtin/html5.nja
+++ b/src/nunja/templates/builtin/html5.nja
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>{% block __nunja_title__ %}{{ __nunja_title__ }}{% endblock %}</title>
+{% block __nunja_head_javascript__ %}
+{% for src in js_src -%}
+  <script type="text/javascript" src="{{ __nunja_js_prefix__ }}{{ src }}"></script>
+{% endfor %}
+{% endblock %}
+{% block __nunja_head_stylesheet__ %}
+{% for src in css_src -%}
+  <link type="text/css" href="{{ __nunja_css_prefix__ }}{{ src }}" rel="stylesheet" />
+{%- endfor %}
+{% endblock %}
+</head>
+<body>
+{% block __nunja_body__ %}{{ body|safe }}{% endblock %}
+</body>
+{% block __nunja_foot_javascript__ %}
+{% endblock %}
+</html>

--- a/src/nunja/testing/mocks.py
+++ b/src/nunja/testing/mocks.py
@@ -57,7 +57,7 @@ def setup_tmp_module(testcase_inst, modname='tmp'):
     sys.modules[modname] = ModuleType(modname)
 
 
-def setup_tmp_mold_templates(testcase_inst):
+def setup_tmp_mold_templates(testcase_inst, namespace='tmp'):
     """
     Set up a temporary module, with a default mold and templates.
 
@@ -71,6 +71,8 @@ def setup_tmp_mold_templates(testcase_inst):
         ('entry_points.txt', '\n'.join([
             '[nunja.mold]',
             'tmp = tmp:root',
+            '[nunja.tmpl]',
+            'templates = tmp:root',
         ])),
     ), 'nunjatesting', '0.0')
 
@@ -83,6 +85,7 @@ def setup_tmp_mold_templates(testcase_inst):
 
     module_map = {
         'tmp': tempdir,
+        'templates': tempdir,
         'nunjatesting': tempdir,
         # include this module, too
         'nunja': resource_filename(Requirement.parse('nunja'), ''),
@@ -109,7 +112,7 @@ def setup_tmp_mold_templates(testcase_inst):
     filter_dump_template = join(molddir, 'filter_dump.nja')
 
     with open(main_template, 'w') as fd:
-        fd.write('<div>{% include "tmp/mold/sub.nja" %}</div>')
+        fd.write('<div>{%% include "%s/mold/sub.nja" %%}</div>' % namespace)
 
     with open(sub_template, 'w') as fd:
         fd.write('<span>{{ data }}</span>')
@@ -135,6 +138,17 @@ def setup_tmp_mold_templates_registry(testcase_inst):
         sub_template) = setup_tmp_mold_templates(testcase_inst)
 
     registry = MoldRegistry('nunja.mold', _working_set=working_set)
+    return registry, main_template, sub_template
+
+
+def setup_tmp_jinja_templates_registry(testcase_inst):
+    from nunja.registry import JinjaTemplateRegistry
+
+    (working_set, main_template,
+        sub_template) = setup_tmp_mold_templates(
+            testcase_inst, namespace='templates')
+
+    registry = JinjaTemplateRegistry('nunja.tmpl', _working_set=working_set)
     return registry, main_template, sub_template
 
 

--- a/src/nunja/tests/test_engine.py
+++ b/src/nunja/tests/test_engine.py
@@ -5,6 +5,7 @@ from os import remove
 from jinja2 import TemplateNotFound
 
 from nunja.engine import Engine
+from nunja.engine import JinjaEngine
 from nunja.testing import mocks
 
 
@@ -81,3 +82,66 @@ class EngineWithTestingMoldTestCase(unittest.TestCase):
         self.assertTrue(tmpl.startswith('<ul'))
         script = engine.fetch_path('nunja.testing.mold/itemlist/index.js')
         self.assertTrue(script.startswith('define(['))
+
+
+class JinjaEngineTestCase(unittest.TestCase):
+    """
+    The core engine test case for testing the integration with the
+    loader.
+    """
+
+    def setUp(self):
+        (registry, self.main_template,
+            self.sub_template) = mocks.setup_tmp_jinja_templates_registry(self)
+        self.engine = JinjaEngine(registry)
+
+    def test_unregistered_not_found(self):
+        with self.assertRaises(TemplateNotFound):
+            self.engine.load_template('some/id')
+
+    def test_base_loading(self):
+        template = self.engine.load_template('templates/mold/sub.nja')
+        result = template.render(data='Hello World!')
+        self.assertEqual(result, '<span>Hello World!</span>')
+        self.assertEqual(result, self.engine.render_template(
+            'templates/mold/sub.nja', {'data': 'Hello World!'}))
+
+    def test_nested_loading(self):
+        template = self.engine.load_template('templates/mold/template.nja')
+        result = template.render(data='Hello World!')
+        self.assertEqual(result, '<div><span>Hello World!</span></div>')
+
+    def test_base_auto_reload(self):
+        template = self.engine.load_template('templates/mold/template.nja')
+        result = template.render(data='Hello World!')
+        self.assertEqual(result, '<div><span>Hello World!</span></div>')
+
+        with open(self.sub_template, 'w') as fd:
+            fd.write('<div>{{ data }}</div>')
+
+        result = template.render(data='Hello World!')
+        self.assertEqual(result, '<div><div>Hello World!</div></div>')
+        remove(self.sub_template)
+
+        with self.assertRaises(TemplateNotFound):
+            # as that was removed
+            template.render(data='Hello World!')
+
+    def test_fetch_path_basic(self):
+        tmpl = self.engine.fetch_path('templates/mold/template.nja')
+        self.assertEqual(
+            '<div>{% include "templates/mold/sub.nja" %}</div>', tmpl)
+
+    def test_filter_dump(self):
+        # To mimic the JSON.stringify filter in nunjucks, provide the
+        # filter under the same name through json.dumps.  This will
+        # test that feature.
+        template = self.engine.load_template('templates/mold/filter_dump.nja')
+        result = template.render(data={
+            'some': 'object', 'items': ['Hello', '<World>']})
+        self.assertEqual(result, (
+            '<div>{'
+            '&#34;items&#34;:[&#34;Hello&#34;,&#34;&lt;World&gt;&#34;],'
+            '&#34;some&#34;:&#34;object&#34;'
+            '}</div>'
+        ))


### PR DESCRIPTION
While this is based on the mold engine, this one has been revamped for templates only and ended up having a similar, but different API.

It may be merged again later, but this is done to avoid confusion of server-side (i.e. Python only) templates being assigned/exported to the front-end JavaScript version.